### PR TITLE
Some cmake changes to compile a 32-bit library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@
 cmake_minimum_required(VERSION 2.8)
 project(libfec ASM C)
 
+option(BUILD_32BIT_ON_64BIT "Build a 32-bit library on a 64-bit system" OFF)
+
 # Select the release build type by default to get optimization flags
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE "Release")
@@ -39,6 +41,14 @@ endif()
 ########################################################################
 # Compiler specific setup
 ########################################################################
+if(BUILD_32BIT_ON_64BIT)
+    set(CMAKE_SYSTEM_PROCESSOR "i386")
+    set(CMAKE_SIZEOF_VOID_P 4)
+    set(CMAKE_C_FLAGS -m32)
+    set(CMAKE_CXX_FLAGS -m32)
+    add_definitions(-m32)
+endif()
+
 if((CMAKE_SYSTEM_PROCESSOR MATCHES "i386|i686|x86|AMD64") AND (CMAKE_SIZEOF_VOID_P EQUAL 4))
     set(TARGET_ARCH "x86")
 elseif((CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|AMD64") AND (CMAKE_SIZEOF_VOID_P EQUAL 8))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -146,9 +146,9 @@ elseif(TARGET_ARCH MATCHES "x86")
         viterbi615_sse2.c
         dotprod_mmx.c
         dotprod_sse2.c
-        peakval_mmx.c
-        peakval_sse.c
-        peakval_sse2.c
+        #peakval_mmx.c
+        #peakval_sse.c
+        #peakval_sse2.c
         sumsq.c
         sumsq_port.c
         sumsq_sse2.c


### PR DESCRIPTION
This pull request adds the following code to the CMakeLists.txt.
1. A cmake option "BUILD_32BIT_ON_64BIT" to compile the library for 32-bit x86 on a 64-bit x64 system. To use it just add " -DBUILD_32BIT_ON_64BIT=ON" to cmake
   
   ```
   cmake ../ -DBUILD_32BIT_ON_64BIT=ON
   ```
2. Fixes the x86 multiple definitions of "peakval_mmx", "peakval_sse2" and "peakval_ss"
   
   ```
   CMakeFiles/libfec_shared.dir/peak_mmx_assist.s.o: In function `peakval_mmx':
   (.text+0x0): multiple definition of `peakval_mmx'
   CMakeFiles/libfec_shared.dir/peakval_mmx.c.o:peakval_mmx.c:(.text+0x0): first defined here
   CMakeFiles/libfec_shared.dir/peak_sse2_assist.s.o: In function `peakval_sse2':
   (.text+0x0): multiple definition of `peakval_sse2'
   CMakeFiles/libfec_shared.dir/peakval_sse2.c.o:peakval_sse2.c:(.text+0x0): first defined here
   CMakeFiles/libfec_shared.dir/peak_sse_assist.s.o: In function `peakval_sse':
   (.text+0x0): multiple definition of `peakval_sse'
   CMakeFiles/libfec_shared.dir/peakval_sse.c.o:peakval_sse.c:(.text+0x0): first defined here
   collect2: error: ld returned 1 exit status
   ```
