### PR TITLE
Add DESTDIR var to makefile

### DIFF
--- a/makefile.in
+++ b/makefile.in
@@ -42,14 +42,14 @@ test: vtest27 vtest29 vtest39 vtest615 rstest dtest sumsq_test peaktest
 	./vtest615
 
 install: all
-	mkdir -p @libdir@ 
-	install -m 644 -p $(SHARED_LIB) libfec.a @libdir@
-#	(cd @libdir@;ln -f -s $(SHARED_LIB) libfec.so)
+	mkdir -p $(DESTDIR)@libdir@ 
+	install -m 644 -p $(SHARED_LIB) libfec.a $(DESTDIR)@libdir@
+#	(cd $(DESTDIR)@libdir@;ln -f -s $(SHARED_LIB) libfec.so)
 	@REBIND@
-	mkdir -p @includedir@
-	install -m 644 -p fec.h @includedir@
-	mkdir -m 0755 -p @mandir@/man3
-	install -m 644 -p simd-viterbi.3 rs.3 dsp.3 @mandir@/man3
+	mkdir -p $(DESTDIR)@includedir@
+	install -m 644 -p fec.h $(DESTDIR)@includedir@
+	mkdir -m 0755 -p $(DESTDIR)@mandir@/man3
+	install -m 644 -p simd-viterbi.3 rs.3 dsp.3 $(DESTDIR)@mandir@/man3
 
 peaktest: peaktest.o libfec.a
 	gcc $(CFLAGS) -g -o $@ $^


### PR DESCRIPTION
This variable (empty by default) is added, because it is needed for Debian-style packaging.
